### PR TITLE
Add an explicit type definition for matches returned by process methods

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -2,8 +2,8 @@
 
 use std::cmp::Ordering;
 
-/// All of the convenience methods in the `process` module return thresholded _matches_. A match
-/// is a set of text which was matched from the list of choices by the provided scoring function,
+/// All of the convenience methods in the `process` module return thresholded scores. A score
+/// is a set of text which was compared against the list of choices by the provided scoring function,
 /// along with the score produced by the scoring function.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Score {
@@ -28,7 +28,7 @@ impl Score {
     }
 }
 
-/// Score ordinality is defined by integer ordinality rules applied on the matches' scores.
+/// Score ordering is based on the ordering of the underlying integer scores.
 impl Ord for Score {
     fn cmp(&self, other: &Self) -> Ordering {
         self.score.cmp(&other.score())
@@ -58,7 +58,7 @@ impl<V: AsRef<str>> PartialEq<(V, u8)> for Score {
 
 /// Score multiple options against a base query string and return all exceeding a cutoff.
 ///
-/// Returns a Vec with the options and their match score if their score is above the cutoff.
+/// Returns a Vec with the options and their query score if their score is above the cutoff.
 /// Results are configurable using custom text processors and scorers.
 /// Good default choices are `utils::full_process` as the processor, `fuzz:wratio` as the scorer, and zero as the score_cutoff.
 ///

--- a/src/process.rs
+++ b/src/process.rs
@@ -2,6 +2,9 @@
 
 use std::cmp::Ordering;
 
+/// All of the convenience methods in the `process` module return thresholded _matches_. A match
+/// is a set of text which was matched from the list of choices by the provided scoring function,
+/// along with the score produced by the scoring function.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Match {
     text: String,
@@ -25,6 +28,7 @@ impl Match {
     }
 }
 
+/// Match ordinality is defined by integer ordinality rules applied on the matches' scores.
 impl Ord for Match {
     fn cmp(&self, other: &Self) -> Ordering {
         self.score.cmp(&other.score())
@@ -37,12 +41,14 @@ impl PartialOrd for Match {
     }
 }
 
+/// Convenience trait `impl` for converting `("text", 100)` to `Match { text: "text".into(), score: 100 }`.
 impl<V: AsRef<str>> From<(V, u8)> for Match {
     fn from((text, score): (V, u8)) -> Self {
         Self::new(text, score)
     }
 }
 
+/// Convenience trait `impl` for comparing `("text", 100)` with `Match { text: "text".into(), score: 100 }`.
 impl<V: AsRef<str>> PartialEq<(V, u8)> for Match {
     fn eq(&self, other: &(V, u8)) -> bool {
         let other_choice = Match::new(other.0.as_ref(), other.1);

--- a/src/process.rs
+++ b/src/process.rs
@@ -6,12 +6,12 @@ use std::cmp::Ordering;
 /// is a set of text which was matched from the list of choices by the provided scoring function,
 /// along with the score produced by the scoring function.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Match {
+pub struct Score {
     text: String,
     score: u8,
 }
 
-impl Match {
+impl Score {
     pub fn new<V: AsRef<str>>(text: V, score: u8) -> Self {
         Self {
             text: text.as_ref().to_string(),
@@ -28,30 +28,30 @@ impl Match {
     }
 }
 
-/// Match ordinality is defined by integer ordinality rules applied on the matches' scores.
-impl Ord for Match {
+/// Score ordinality is defined by integer ordinality rules applied on the matches' scores.
+impl Ord for Score {
     fn cmp(&self, other: &Self) -> Ordering {
         self.score.cmp(&other.score())
     }
 }
 
-impl PartialOrd for Match {
+impl PartialOrd for Score {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.score.partial_cmp(&other.score())
     }
 }
 
-/// Convenience trait `impl` for converting `("text", 100)` to `Match { text: "text".into(), score: 100 }`.
-impl<V: AsRef<str>> From<(V, u8)> for Match {
+/// Convenience trait `impl` for converting `("text", 100)` to `Score { text: "text".into(), score: 100 }`.
+impl<V: AsRef<str>> From<(V, u8)> for Score {
     fn from((text, score): (V, u8)) -> Self {
         Self::new(text, score)
     }
 }
 
-/// Convenience trait `impl` for comparing `("text", 100)` with `Match { text: "text".into(), score: 100 }`.
-impl<V: AsRef<str>> PartialEq<(V, u8)> for Match {
+/// Convenience trait `impl` for comparing `("text", 100)` with `Score { text: "text".into(), score: 100 }`.
+impl<V: AsRef<str>> PartialEq<(V, u8)> for Score {
     fn eq(&self, other: &(V, u8)) -> bool {
-        let other_choice = Match::new(other.0.as_ref(), other.1);
+        let other_choice = Score::new(other.0.as_ref(), other.1);
         self.eq(&other_choice)
     }
 }
@@ -92,7 +92,7 @@ pub fn extract_without_order<I, T, P, S, Q>(
     processor: P,
     scorer: S,
     score_cutoff: u8,
-) -> Vec<Match>
+) -> Vec<Score>
 where
     I: IntoIterator<Item = T>,
     T: AsRef<str>,
@@ -115,7 +115,7 @@ where
         let processed: String = processor(choice.as_ref(), false);
         let score: u8 = scorer(processed_query.as_str(), processed.as_str(), true, true);
         if score >= score_cutoff {
-            results.push(Match::new(choice, score))
+            results.push(Score::new(choice, score))
         }
     }
     results
@@ -189,7 +189,7 @@ pub fn extract_one<I, T, P, S, Q>(
     processor: P,
     scorer: S,
     score_cutoff: u8,
-) -> Option<Match>
+) -> Option<Score>
 where
     I: IntoIterator<Item = T>,
     T: AsRef<str>,


### PR DESCRIPTION
Add an explicit type definition `Match` for matches returned by `process` methods (containing matched text and a score). This is helpful when adding behavior involving sorting or comparison, and provides more semantic meaning by using `m.text()` or `m.score()` instead of `m.0` or `m.1` respectively.

Includes a few convenience `impl`s for creating a `Match` from and comparing a `Match` to `(&str, u8)`.

Depends on: #14 