### PR TITLE
Add additional convenience methods: process::{dedupe, extract}

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a Rust port of the Python package [fuzzywuzzy](https://github.com/seatge
 
 At the time of writing, our matching algorithm is based on the difflib implementation results which may, in rare cases, [have slightly different results](https://github.com/seatgeek/fuzzywuzzy/issues/128) compared to the Python Levenshtein implementation.
 
-**NOTE: This project was originally named `fuzzyrusty`, but _someone else_ cloned and [published it to crates.io](https://crates.io/crates/fuzzyrusty). _We do not control that crate._ This is why we have changed the name.**
+**NOTE: This project was originally named `fuzzyrusty`, but _someone else_ cloned and [published it to crates.io](https://crates.io/crates/fuzzyrusty). _We do not control that crate_, so we have renamed this crate to clearly identify as a port of the original.**
 
 ## Installation
 `fuzzywuzzy` is currently available through GitHub or crates.io.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a Rust port of the Python package [fuzzywuzzy](https://github.com/seatge
 
 At the time of writing, our matching algorithm is based on the difflib implementation results which may, in rare cases, [have slightly different results](https://github.com/seatgeek/fuzzywuzzy/issues/128) compared to the Python Levenshtein implementation.
 
-**Note: This project was originally named `fuzzyrusty`. Someone else cloned and [published it to crates.io](https://crates.io/crates/fuzzyrusty). _We do not control that crate._ This is why we have changed the name.**
+**NOTE: This project was originally named `fuzzyrusty`, but _someone else_ cloned and [published it to crates.io](https://crates.io/crates/fuzzyrusty). _We do not control that crate._ This is why we have changed the name.**
 
 ## Installation
 `fuzzywuzzy` is currently available through GitHub or crates.io.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # fuzzywuzzy-rs
-Fuzzy string matching like a boss. It uses Levenshtein Distance to calculate the differences between sequences in a simple-to-use package.
+> Fuzzy string matching like a boss. It uses Levenshtein Distance to calculate the differences between sequences in a simple-to-use package.
+> [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy)
+
+This is a Rust clone of the python package fuzzywuzzy. We attempt to be 100% compatible with the python version.
+
+At the time of writing, our matching algorithm is based on the difflib implementation results which may, in rare cases, [have slightly different results](https://github.com/seatgeek/fuzzywuzzy/issues/128) compared to the python Levenshtein implementation.
 
 **Note: This project was originally named `fuzzyrusty`. Someone else cloned and published it to crates.io https://crates.io/crates/fuzzyrusty. _We do not control that crate._ This is why we have changed the name.**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# fuzzywuzzy-rs [![docs.rs badge](https://docs.rs/fuzzywuzzy/badge.svg)](https://docs.rs/fuzzywuzzy) [![crates.io badge](https://img.shields.io/crates/v/fuzzywuzzy.svg)](https://crates.io/crates/fuzzywuzzy)
+# fuzzywuzzy-rs
+
+[![docs.rs badge](https://docs.rs/fuzzywuzzy/badge.svg)](https://docs.rs/fuzzywuzzy) [![crates.io badge](https://img.shields.io/crates/v/fuzzywuzzy.svg)](https://crates.io/crates/fuzzywuzzy)
+
 > Fuzzy string matching like a boss. It uses Levenshtein Distance to calculate the differences between sequences in a simple-to-use package.
 > [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > Fuzzy string matching like a boss. It uses Levenshtein Distance to calculate the differences between sequences in a simple-to-use package.
 > [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy)
 
-This is a Rust clone of the python package fuzzywuzzy. We attempt to be 100% compatible with the python version.
+This is a Rust port of the Python package fuzzywuzzy. We aim to be drop-in replacement for the original.
 
 At the time of writing, our matching algorithm is based on the difflib implementation results which may, in rare cases, [have slightly different results](https://github.com/seatgeek/fuzzywuzzy/issues/128) compared to the python Levenshtein implementation.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 This is a Rust port of the Python package fuzzywuzzy. We aim to be a drop-in replacement for the original.
 
-At the time of writing, our matching algorithm is based on the difflib implementation results which may, in rare cases, [have slightly different results](https://github.com/seatgeek/fuzzywuzzy/issues/128) compared to the python Levenshtein implementation.
+At the time of writing, our matching algorithm is based on the difflib implementation results which may, in rare cases, [have slightly different results](https://github.com/seatgeek/fuzzywuzzy/issues/128) compared to the Python Levenshtein implementation.
 
-**Note: This project was originally named `fuzzyrusty`. Someone else cloned and published it to crates.io https://crates.io/crates/fuzzyrusty. _We do not control that crate._ This is why we have changed the name.**
+**Note: This project was originally named `fuzzyrusty`. Someone else cloned and [published it to crates.io](https://crates.io/crates/fuzzyrusty). _We do not control that crate._ This is why we have changed the name.**
 
 ## Installation
 `fuzzywuzzy` is currently available through GitHub or crates.io.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ At the time of writing, our matching algorithm is based on the difflib implement
 ## Installation
 `fuzzywuzzy` is currently available through GitHub or crates.io.
 
-For the latest stable releas, add this to your `Cargo.toml`:
+For the latest stable release, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -29,7 +29,7 @@ fuzzywuzzy = { git = "https://github.com/logannc/fuzzywuzzy-rs", branch = "maste
 ```
 
 ## Documentation
-Clone the repository and run `$ cargo doc --open`.
+Clone the repository and run `$ cargo doc --open`, or visit [docs.rs](https://docs.rs/crate/fuzzywuzzy/0.0.2).
 
 ## Usage
 ### Simple Ratio

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > Fuzzy string matching like a boss. It uses Levenshtein Distance to calculate the differences between sequences in a simple-to-use package.
 > [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy)
 
-This is a Rust port of the Python package fuzzywuzzy. We aim to be drop-in replacement for the original.
+This is a Rust port of the Python package fuzzywuzzy. We aim to be a drop-in replacement for the original.
 
 At the time of writing, our matching algorithm is based on the difflib implementation results which may, in rare cases, [have slightly different results](https://github.com/seatgeek/fuzzywuzzy/issues/128) compared to the python Levenshtein implementation.
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 [![docs.rs badge](https://docs.rs/fuzzywuzzy/badge.svg)](https://docs.rs/fuzzywuzzy) [![crates.io badge](https://img.shields.io/crates/v/fuzzywuzzy.svg)](https://crates.io/crates/fuzzywuzzy)
 
 > Fuzzy string matching like a boss. It uses Levenshtein Distance to calculate the differences between sequences in a simple-to-use package.
-> [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy)
 
-This is a Rust port of the Python package fuzzywuzzy. We aim to be a drop-in replacement for the original.
+This is a Rust port of the Python package [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy). We aim to be a drop-in replacement for the original.
 
 At the time of writing, our matching algorithm is based on the difflib implementation results which may, in rare cases, [have slightly different results](https://github.com/seatgeek/fuzzywuzzy/issues/128) compared to the Python Levenshtein implementation.
 

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use utils;
 
 pub fn ratio(s1: &str, s2: &str) -> u8 {
+    check_trivial!(s1, s2);
     let (shorter, longer) = if s1.len() <= s2.len() {
         (s1, s2)
     } else {
@@ -21,6 +22,7 @@ pub fn ratio(s1: &str, s2: &str) -> u8 {
 
 /// Return the ratio of the most similar substring as a number between 0 and 100.
 pub fn partial_ratio(s1: &str, s2: &str) -> u8 {
+    check_trivial!(s1, s2);
     let (shorter, longer) = if s1.len() <= s2.len() {
         (s1.to_string(), s2.to_string())
     } else {
@@ -59,6 +61,7 @@ fn process_and_sort(s: &str, force_ascii: bool, full_process: bool) -> String {
 /// # sort those tokens and take ratio of resulting joined strings
 /// # controls for unordered string elements
 fn token_sort(s1: &str, s2: &str, partial: bool, force_ascii: bool, full_process: bool) -> u8 {
+    check_trivial!(s1, s2);
     let sorted1 = process_and_sort(s1, force_ascii, full_process);
     let sorted2 = process_and_sort(s2, force_ascii, full_process);
     if partial {
@@ -73,6 +76,7 @@ fn token_sort(s1: &str, s2: &str, partial: bool, force_ascii: bool, full_process
 ///
 /// By default, force_ascii and full_process should be true.
 pub fn token_sort_ratio(s1: &str, s2: &str, force_ascii: bool, full_process: bool) -> u8 {
+    // trivial check omitted because this is a shallow delegator to token_sort which checks.
     token_sort(s1, s2, false, force_ascii, full_process)
 }
 
@@ -81,6 +85,7 @@ pub fn token_sort_ratio(s1: &str, s2: &str, force_ascii: bool, full_process: boo
 ///
 /// By default, force_ascii and full_process should be true.
 pub fn partial_token_sort_ratio(s1: &str, s2: &str, force_ascii: bool, full_process: bool) -> u8 {
+    // trivial check omitted because this is a shallow delegator to token_sort which checks.
     token_sort(s1, s2, true, force_ascii, full_process)
 }
 
@@ -90,6 +95,7 @@ pub fn partial_token_sort_ratio(s1: &str, s2: &str, force_ascii: bool, full_proc
 ///  # take ratios of those two strings
 ///  # controls for unordered partial matches
 fn token_set(s1: &str, s2: &str, partial: bool, force_ascii: bool, full_process: bool) -> u8 {
+    check_trivial!(s1, s2);
     let (p1, p2) = if full_process {
         (
             utils::full_process(s1, force_ascii),
@@ -141,10 +147,12 @@ fn token_set(s1: &str, s2: &str, partial: bool, force_ascii: bool, full_process:
 }
 
 pub fn token_set_ratio(s1: &str, s2: &str, force_ascii: bool, full_process: bool) -> u8 {
+    // trivial check omitted because this is a shallow delegator to token_set which checks.
     token_set(s1, s2, false, force_ascii, full_process)
 }
 
 pub fn partial_token_set_ratio(s1: &str, s2: &str, force_ascii: bool, full_process: bool) -> u8 {
+    // trivial check omitted because this is a shallow delegator to token_set which checks.
     token_set(s1, s2, true, force_ascii, full_process)
 }
 
@@ -153,6 +161,7 @@ pub fn partial_token_set_ratio(s1: &str, s2: &str, force_ascii: bool, full_proce
 //  Runs utils::full_process on both strings.
 //  Short circuits if either of the strings is empty after processing.
 pub fn qratio(s1: &str, s2: &str, force_ascii: bool) -> u8 {
+    check_trivial!(s1, s2);
     let (p1, p2) = (
         utils::full_process(s1, force_ascii),
         utils::full_process(s2, force_ascii),
@@ -164,6 +173,7 @@ pub fn qratio(s1: &str, s2: &str, force_ascii: bool) -> u8 {
 }
 
 pub fn uqratio(s1: &str, s2: &str) -> u8 {
+    // trivial check omitted because this is a shallow delegator to qratio which checks.
     qratio(s1, s2, false)
 }
 
@@ -189,6 +199,7 @@ pub fn uqratio(s1: &str, s2: &str) -> u8 {
 /// #. Take the highest value from these results
 ///    round it and return it as an integer.
 pub fn wratio(s1: &str, s2: &str, force_ascii: bool, full_process: bool) -> u8 {
+    check_trivial!(s1, s2);
     let (p1, p2) = if full_process {
         (
             utils::full_process(s1, force_ascii),
@@ -242,6 +253,7 @@ pub fn wratio(s1: &str, s2: &str, force_ascii: bool, full_process: bool) -> u8 {
 }
 
 pub fn uwratio(s1: &str, s2: &str, full_process: bool) -> u8 {
+    // trivial check omitted because this is a shallow delegator to wratio which checks.
     wratio(s1, s2, false, full_process)
 }
 

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -269,6 +269,7 @@ mod tests {
         s3: &'static str,
         s4: &'static str,
         s5: &'static str,
+        #[allow(dead_code)]
         s6: &'static str,
         s7: &'static str,
         s8: &'static str,
@@ -277,8 +278,9 @@ mod tests {
         s9a: &'static str,
         s10: &'static str,
         s10a: &'static str,
-        // TODO: Test silly corner cases,
+        #[allow(dead_code)]
         cirque_strings: &'static [&'static str; 6],
+        #[allow(dead_code)]
         baseball_strings: &'static [&'static str; 4],
     }
 
@@ -422,7 +424,6 @@ mod tests {
 
     #[test]
     fn test_empty_string_score_100() {
-        let f = Fixture::new();
         assert_eq!(fuzz::ratio("", ""), 100);
         assert_eq!(fuzz::partial_ratio("", ""), 100);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 #[macro_use]
 pub mod utils;
 pub mod fuzz;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[macro_use]
+pub mod utils;
 pub mod fuzz;
 pub mod process;
-pub mod utils;

--- a/src/process.rs
+++ b/src/process.rs
@@ -2,6 +2,9 @@
 
 use std::cmp::Ordering;
 
+/// All of the convenience methods in the `process` module return thresholded _matches_. A match
+/// is a set of text which was matched from the list of choices by the provided scoring function,
+/// along with the score produced by the scoring function.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Match {
     text: String,
@@ -25,6 +28,7 @@ impl Match {
     }
 }
 
+/// Match ordinality is defined by integer ordinality rules applied on the matches' scores.
 impl Ord for Match {
     fn cmp(&self, other: &Self) -> Ordering {
         self.score.cmp(&other.score())
@@ -37,12 +41,14 @@ impl PartialOrd for Match {
     }
 }
 
+/// Convenience trait `impl` for converting `("text", 100)` to `Match { text: "text".into(), score: 100 }`.
 impl<V: AsRef<str>> From<(V, u8)> for Match {
     fn from((text, score): (V, u8)) -> Self {
         Self::new(text, score)
     }
 }
 
+/// Convenience trait `impl` for comparing `("text", 100)` with `Match { text: "text".into(), score: 100 }`.
 impl<V: AsRef<str>> PartialEq<(V, u8)> for Match {
     fn eq(&self, other: &(V, u8)) -> bool {
         let other_choice = Match::new(other.0.as_ref(), other.1);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-/// Standalone functions used by the rest of the crate. You might also find them useful.
+//! Standalone functions used by the rest of the crate. You might also find them useful.
 
 /// Used to preprocess strings into 'canonical' forms.
 ///
@@ -15,8 +15,18 @@
 /// assert_eq!(full_process("Ça va?", false), "ça va");
 /// assert_eq!(full_process("Cães danados", false), "cães danados");
 /// assert_eq!(full_process("¬Camarões assados", false), "camarões assados");
-/// assert_eq!(full_process("a¬1ሴ1€耀", false), "a 1ሴ1 耀");
+/// assert_eq!(full_process("a¬4ሴ2€耀", false), "a 4ሴ2 耀");
 /// assert_eq!(full_process("Á", false), "á");
+///
+/// assert_eq!(full_process("Lorem Ipsum", true), "lorem ipsum");
+/// assert_eq!(full_process("C'est la vie", true), "c est la vie");
+/// assert_eq!(full_process("Ça va?", true), "a va");
+/// assert_eq!(full_process("Cães danados", true), "ces danados");
+/// assert_eq!(full_process("¬Camarões assados", true), "camares assados");
+/// // Notice that the filtering of non-ascii values occurs *before* replacing
+/// // non-alphanumeric with whitespace, which changes the result dramatically.
+/// assert_eq!(full_process("a¬4ሴ2€耀", true), "a42");
+/// assert_eq!(full_process("Á", true), "");
 /// ```
 pub fn full_process(s: &str, force_ascii: bool) -> String {
     let mut result = s.to_string();
@@ -32,7 +42,7 @@ pub fn full_process(s: &str, force_ascii: bool) -> String {
 
 /// A vestigial function from the port from Python's fuzzywuzzy.
 ///
-/// We, `fuzzywuzzy-rs`, attempt to maintain identical results with `fuzzywuzzy-py`.
+/// We, [`fuzzywuzzy-rs`](https://github.com/logannc/fuzzywuzzy-rs), attempt to maintain identical results with [`fuzzywuzzy-py`](https://github.com/seatgeek/fuzzywuzzy).
 /// This function has been kept so that if the python version adds constraints, it is easy to propagate.
 ///
 /// It makes sure the string is non-empty.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,23 @@
-/// Process string by
-/// # removing all but letters and numbers
-/// # trim whitespace
-/// # force to lower case
+/// Standalone functions used by the rest of the crate. You might also find them useful.
+
+/// Used to preprocess strings into 'canonical' forms.
 ///
-/// If force_ascii == true, force convert to ascii. By default, this is false.
+/// Process string by
+/// 1. if `force_ascii`, remove non-ascii characters
+/// 2. replace all non-alphanumeric characters with a space
+/// 3. force to lower case
+/// 4. trim whitespace
+///
+/// ```
+/// # use fuzzywuzzy::utils::full_process;
+/// assert_eq!(full_process("Lorem Ipsum", false), "lorem ipsum");
+/// assert_eq!(full_process("C'est la vie", false), "c est la vie");
+/// assert_eq!(full_process("Ça va?", false), "ça va");
+/// assert_eq!(full_process("Cães danados", false), "cães danados");
+/// assert_eq!(full_process("¬Camarões assados", false), "camarões assados");
+/// assert_eq!(full_process("a¬1ሴ1€耀", false), "a 1ሴ1 耀");
+/// assert_eq!(full_process("Á", false), "á");
+/// ```
 pub fn full_process(s: &str, force_ascii: bool) -> String {
     let mut result = s.to_string();
     if force_ascii {
@@ -13,11 +27,21 @@ pub fn full_process(s: &str, force_ascii: bool) -> String {
         .chars()
         .map(|c| if c.is_alphanumeric() { c } else { ' ' })
         .collect();
-    result.make_ascii_lowercase();
-    result.trim().to_string()
+    result.to_lowercase().trim().into()
 }
 
-/// Ensures that the input string is non-empty.
+/// A vestigial function from the port from Python's fuzzywuzzy.
+///
+/// We, `fuzzywuzzy-rs`, attempt to maintain identical results with `fuzzywuzzy-py`.
+/// This function has been kept so that if the python version adds constraints, it is easy to propagate.
+///
+/// It makes sure the string is non-empty.
+///
+/// ```
+/// # use fuzzywuzzy::utils::validate_string;
+/// assert_eq!(validate_string(""), false);
+/// assert_eq!(validate_string("anything else"), true);
+/// ```
 pub fn validate_string(s: &str) -> bool {
     !s.is_empty()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -90,6 +90,18 @@ fn find_longest_match<'a>(
     (low1, low2, 0)
 }
 
+/// Returns list of triples describing matching sequences.
+///
+/// The first number is the index in the first string of the beginning of the match.
+/// The second number is the index of the second string of the beginning of the match.
+/// The final number is the length of the match.
+///
+/// The final matching sequence will be a trivial matching sequence of (a.len(), b.len(), 0) and will be the only match of length 0.
+///
+/// ```
+/// # use fuzzywuzzy::utils::get_matching_blocks;
+/// assert_eq!(get_matching_blocks("abxcd", "abcd"), vec![(0, 0, 2), (3, 2, 2), (5, 4, 0)]);
+/// ```
 pub fn get_matching_blocks<'a>(shorter: &'a str, longer: &'a str) -> Vec<(usize, usize, usize)> {
     // https://github.com/python-git/python/blob/master/Lib/difflib.py#L461
     let (len1, len2) = (shorter.len(), longer.len());
@@ -127,4 +139,18 @@ pub fn get_matching_blocks<'a>(shorter: &'a str, longer: &'a str) -> Vec<(usize,
     }
     non_adjacent.push((len1, len2, 0));
     non_adjacent
+}
+
+/// some common short circuiting for ratio finding functions.
+/// If the strings are equal, they have a ratio of 100%.
+/// If only one of the strings is empty, they have a ratio of 0%.
+macro_rules! check_trivial {
+    ($s1:expr, $s2:expr) => {
+        if $s1 == $s2 {
+            return 100;
+        }
+        if $s1.is_empty() ^ $s2.is_empty() {
+            return 0;
+        }
+    };
 }


### PR DESCRIPTION
I've added [`dedupe`](https://github.com/seatgeek/fuzzywuzzy/blob/master/fuzzywuzzy/process.py#L225) and [`extract`](https://github.com/seatgeek/fuzzywuzzy/blob/master/fuzzywuzzy/process.py#L122), along with a single unit-test for both. 

However, the dedupe test is failing, as it seems to be returning the shortest duplicate, whereas the "canonical" duplicate is meant to be the longest duplicate (as it contains the most entity information). @logannc, I would appreciate your help debugging this issue... it seems similar to the `max_by` issue with `extract_one` that required a reversal of the matches. 

I was going to add [`extract_bests`](https://github.com/seatgeek/fuzzywuzzy/blob/master/fuzzywuzzy/process.py#L172), but it does not seem to differ in implementation (beyond defaults) from `extract`, so I've commented out the (duplicate) implementation.

Closes: #7 
Depends on: #15