### PR TITLE
Fix unicode panics

### DIFF
--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -96,7 +96,7 @@ fn process_and_sort(s: &str, force_ascii: bool, full_process: bool) -> String {
         s.to_string()
     };
     let mut ts_split: Vec<_> = ts.split_whitespace().collect();
-    ts_split.sort();
+    ts_split.sort_unstable();
     ts_split.join(" ")
 }
 
@@ -178,9 +178,9 @@ fn token_set(s1: &str, s2: &str, partial: bool, force_ascii: bool, full_process:
     let mut intersection: Vec<_> = t1.intersection(&t2).cloned().collect();
     let mut diff1to2: Vec<_> = t1.difference(&t2).cloned().collect();
     let mut diff2to1: Vec<_> = t2.difference(&t1).cloned().collect();
-    intersection.sort();
-    diff1to2.sort();
-    diff2to1.sort();
+    intersection.sort_unstable();
+    diff1to2.sort_unstable();
+    diff2to1.sort_unstable();
     let intersect_str = intersection.join(" ");
     let diff1to2_str = diff1to2.join(" ");
     let diff2to1_str = diff2to1.join(" ");

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -29,7 +29,7 @@ pub fn ratio(a: &str, b: &str) -> u8 {
         .iter()
         .map(|&(_, _, s)| s)
         .sum();
-    let sumlength: f32 = (a.len() + b.len()) as f32;
+    let sumlength: f32 = (a.chars().count() + b.chars().count()) as f32;
     if sumlength > 0.0 {
         (100.0 * (2.0 * (matches as f32) / sumlength)).round() as u8
     } else {
@@ -67,7 +67,7 @@ pub fn ratio(a: &str, b: &str) -> u8 {
 /// ```
 pub fn partial_ratio(s1: &str, s2: &str) -> u8 {
     check_trivial!(s1, s2);
-    let (shorter, longer) = if s1.len() <= s2.len() {
+    let (shorter, longer) = if s1.chars().count() <= s2.chars().count() {
         (s1, s2)
     } else {
         (s2, s1)
@@ -76,7 +76,7 @@ pub fn partial_ratio(s1: &str, s2: &str) -> u8 {
     let mut max: u8 = 0;
     for (i, j, _) in blocks {
         let long_start = if j > i { j - i } else { 0 };
-        let long_end = std::cmp::min(long_start + shorter.len(), longer.len());
+        let long_end = std::cmp::min(long_start + shorter.chars().count(), longer.chars().count());
         let long_substr = &longer[long_start..long_end];
         let r = ratio(shorter, long_substr);
         if r > 99 {
@@ -341,8 +341,8 @@ pub fn wratio(s1: &str, s2: &str, force_ascii: bool, full_process: bool) -> u8 {
     let mut partial_scale = 0.90;
 
     let base = ratio(p1r, p2r);
-    let len_ratio =
-        std::cmp::max(p1.len(), p2.len()) as f64 / std::cmp::min(p1.len(), p2.len()) as f64;
+    let (p1_len, p2_len) = (p1.chars().count(), p2.chars().count());
+    let len_ratio = std::cmp::max(p1_len, p2_len) as f64 / std::cmp::min(p1_len, p2_len) as f64;
 
     // if strings are similar length, don't use partials
     if len_ratio < 1.5 {

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -381,3 +381,29 @@ pub fn uwratio(s1: &str, s2: &str, full_process: bool) -> u8 {
     // trivial check omitted because this is a shallow delegator to wratio which checks.
     wratio(s1, s2, false, full_process)
 }
+
+#[cfg(test)]
+mod test {
+    use super::ratio;
+    #[test]
+    fn ratio_unicode() {
+        let list = [
+            "スマホでchance",
+            "học",
+            "ρɪc",
+            "quốc",
+            "trước",
+            "thực",
+            "我刚上传了一张照片到facebook",
+            "お名前.com",
+            "っˇωˇc",
+            "出会いを探すならpcmax",
+            "化粧cas",
+            "fòllòwbáck",
+        ];
+        for word in list.iter() {
+            eprintln!("word: {:?}", word);
+            ratio("abcde", word);
+        }
+    }
+}

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -388,22 +388,21 @@ mod test {
     #[test]
     fn ratio_unicode() {
         let list = [
-            "スマホでchance",
-            "học",
-            "ρɪc",
-            "quốc",
-            "trước",
-            "thực",
-            "我刚上传了一张照片到facebook",
-            "お名前.com",
-            "っˇωˇc",
-            "出会いを探すならpcmax",
-            "化粧cas",
-            "fòllòwbáck",
+            ("スマホでchance", "chance", 75),
+            ("học", "hoc", 67),
+            ("ρɪc", "pic", 33),
+            ("quốc", "quoc", 75),
+            ("trước", "truoc", 60),
+            ("thực", "thuc", 75),
+            ("我刚上传了一张照片到facebook", "facebook", 62),
+            ("お名前.com", "com", 60),
+            ("っˇωˇc", "w", 0),
+            ("出会いを探すならpcmax", "pcmax", 56),
+            ("化粧cas", "cas", 75),
+            ("fòllòwbáck", "followback", 70),
         ];
-        for word in list.iter() {
-            eprintln!("word: {:?}", word);
-            ratio("abcde", word);
+        for (a, b, r) in list.iter() {
+            assert_eq!(ratio(a, b), *r);
         }
     }
 }

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -29,7 +29,7 @@ pub fn ratio(a: &str, b: &str) -> u8 {
         .iter()
         .map(|&(_, _, s)| s)
         .sum();
-    let sumlength: f32 = (a.len() + b.len()) as f32;
+    let sumlength: f32 = (a.chars().count() + b.chars().count()) as f32;
     if sumlength > 0.0 {
         (100.0 * (2.0 * (matches as f32) / sumlength)).round() as u8
     } else {
@@ -67,7 +67,7 @@ pub fn ratio(a: &str, b: &str) -> u8 {
 /// ```
 pub fn partial_ratio(s1: &str, s2: &str) -> u8 {
     check_trivial!(s1, s2);
-    let (shorter, longer) = if s1.len() <= s2.len() {
+    let (shorter, longer) = if s1.chars().count() <= s2.chars().count() {
         (s1, s2)
     } else {
         (s2, s1)
@@ -76,7 +76,7 @@ pub fn partial_ratio(s1: &str, s2: &str) -> u8 {
     let mut max: u8 = 0;
     for (i, j, _) in blocks {
         let long_start = if j > i { j - i } else { 0 };
-        let long_end = std::cmp::min(long_start + shorter.len(), longer.len());
+        let long_end = std::cmp::min(long_start + shorter.chars().count(), longer.chars().count());
         let long_substr = &longer[long_start..long_end];
         let r = ratio(shorter, long_substr);
         if r > 99 {
@@ -96,7 +96,7 @@ fn process_and_sort(s: &str, force_ascii: bool, full_process: bool) -> String {
         s.to_string()
     };
     let mut ts_split: Vec<_> = ts.split_whitespace().collect();
-    ts_split.sort();
+    ts_split.sort_unstable();
     ts_split.join(" ")
 }
 
@@ -178,9 +178,9 @@ fn token_set(s1: &str, s2: &str, partial: bool, force_ascii: bool, full_process:
     let mut intersection: Vec<_> = t1.intersection(&t2).cloned().collect();
     let mut diff1to2: Vec<_> = t1.difference(&t2).cloned().collect();
     let mut diff2to1: Vec<_> = t2.difference(&t1).cloned().collect();
-    intersection.sort();
-    diff1to2.sort();
-    diff2to1.sort();
+    intersection.sort_unstable();
+    diff1to2.sort_unstable();
+    diff2to1.sort_unstable();
     let intersect_str = intersection.join(" ");
     let diff1to2_str = diff1to2.join(" ");
     let diff2to1_str = diff2to1.join(" ");
@@ -341,8 +341,8 @@ pub fn wratio(s1: &str, s2: &str, force_ascii: bool, full_process: bool) -> u8 {
     let mut partial_scale = 0.90;
 
     let base = ratio(p1r, p2r);
-    let len_ratio =
-        std::cmp::max(p1.len(), p2.len()) as f64 / std::cmp::min(p1.len(), p2.len()) as f64;
+    let (p1_len, p2_len) = (p1.chars().count(), p2.chars().count());
+    let len_ratio = std::cmp::max(p1_len, p2_len) as f64 / std::cmp::min(p1_len, p2_len) as f64;
 
     // if strings are similar length, don't use partials
     if len_ratio < 1.5 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-#![deny(warnings)]
+//! Fuzzy string matching like
+//! [FuzzyWuzzy.py](https://github.com/seatgeek/fuzzywuzzy) like a boss. It uses
+//! [Levenshtein Distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
+//! to calculate the differences between sequences in a simple-to-use package.
 
 #[macro_use]
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 //! Fuzzy string matching like
 //! [FuzzyWuzzy.py](https://github.com/seatgeek/fuzzywuzzy) like a boss. It uses
 //! [Levenshtein Distance](https://en.wikipedia.org/wiki/Levenshtein_distance)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,8 +42,11 @@ pub fn full_process(s: &str, force_ascii: bool) -> String {
 
 /// A vestigial function from the port from Python's fuzzywuzzy.
 ///
-/// We, [`fuzzywuzzy-rs`](https://github.com/logannc/fuzzywuzzy-rs), attempt to maintain identical results with [`fuzzywuzzy-py`](https://github.com/seatgeek/fuzzywuzzy).
-/// This function has been kept so that if the python version adds constraints, it is easy to propagate.
+/// We, [`fuzzywuzzy-rs`](https://github.com/logannc/fuzzywuzzy-rs), attempt to
+/// maintain identical results with
+/// [`fuzzywuzzy-py`](https://github.com/seatgeek/fuzzywuzzy). This function has
+/// been kept so that if the python version adds constraints, it is easy to
+/// propagate.
 ///
 /// It makes sure the string is non-empty.
 ///
@@ -54,6 +57,66 @@ pub fn full_process(s: &str, force_ascii: bool) -> String {
 /// ```
 pub fn validate_string(s: &str) -> bool {
     !s.is_empty()
+}
+
+#[cfg(test)]
+mod test {
+    #[allow(unused_imports)]
+    use super::*;
+    #[test]
+    fn slice_in_the_middle() {
+        let s = "this is a test"; // No unicode
+        assert_eq!(slice_utf8(s, 3, 6), Some(&s[3..6]));
+    }
+    #[test]
+    fn slice_in_the_utf8() {
+        let s = "ϵthiϕś αβ a test"; // Unicode
+        assert_eq!(slice_utf8(s, 2, 6), Some("hiϕś"));
+    }
+}
+
+/// A function to handle slicing into strings which may contain unicode.
+///
+/// Unlike Python, Rust cares deeply about unicode strings and ensuring every
+/// slice into them remains valid. As sliceing assumes that each enicode
+/// charicter is either in or outside of a slice, a simple slice operation can
+/// panic when run on a Rust string. We manually slice a Rust string by
+/// iterating over it's charicter points. This avoids panic on unicode strings.
+///
+/// typical usage would be:
+///     `slice_utf8(simple_string, 3, 7)` instead of `&simple_string[3..7]``
+///
+fn slice_utf8<'a>(string: &'a str, low: usize, high: usize) -> Option<&'a str> {
+    let mut indices = string.char_indices().enumerate().map(|(e, (i, _))| (i, e));
+    let mut low_index = None;
+    let mut high_index = None;
+    for (i, e) in &mut indices {
+        if e == low {
+            low_index = Some(i);
+            break;
+        }
+    }
+    if low + 1 == high {
+        high_index = if let Some((i, _)) = indices.next() {
+            Some(i)
+        } else {
+            low_index.map(|l| l + 1)
+        };
+    } else {
+        for (i, e) in &mut indices {
+            // Rust excludes the last index
+            if e + 1 == high {
+                if let Some((i, _)) = indices.next() {
+                    high_index = Some(i);
+                } else {
+                    high_index = Some(i + 1);
+                }
+                break;
+            }
+        }
+    }
+
+    low_index.zip(high_index).map(|(l, h)| &string[l..h])
 }
 
 fn find_longest_match<'a>(
@@ -69,21 +132,32 @@ fn find_longest_match<'a>(
     //  In other words, of all maximal matching blocks, return one that
     //  starts earliest in a, and of all those maximal matching blocks that
     //  start earliest in a, return the one that starts earliest in b.
-
-    // In MY words:
-    // So, try to find a block of size shorter.len(), else decrement size.
-    // for each block size, start from the front of a and return if only one match
-    // If multiple matches for a given block size and index, return the one that starts
-    // earliest in b.
-    let longsub = &longer[low2..high2];
+    //
+    // In MY words: So, try to find a block of size shorter.len(), else
+    // decrement size. for each block size, start from the front of a and return
+    // if only one match If multiple matches for a given block size and index,
+    // return the one that starts earliest in b.
+    let longsub = slice_utf8(longer, low2, high2).unwrap();
+    let backup = &longer[low2..high2];
+    if longsub != backup {
+        println!(
+            "backup: {:?} != longsub: {:?} on string: {:?}[{}..{}] with len {}",
+            backup,
+            longsub,
+            longer,
+            low2,
+            high2,
+            longer.chars().count()
+        )
+    }
     let slen = high1 - low1;
     for size in (1..slen + 1).rev() {
         for start in 0..slen - size + 1 {
-            let substr = &shorter[low1 + start..low1 + start + size];
+            let substr = slice_utf8(&shorter, low1 + start, low1 + start + size).unwrap();
             let matches: Vec<(usize, &'a str)> = longsub.match_indices(substr).collect();
             // Does this need to be sorted?
             if let Some(&(startb, matchstr)) = matches.first() {
-                return (low1 + start, low2 + startb, matchstr.len());
+                return (low1 + start, low2 + startb, matchstr.chars().count());
             }
         }
     }
@@ -96,7 +170,8 @@ fn find_longest_match<'a>(
 /// The second number is the index of the second string of the beginning of the match.
 /// The final number is the length of the match.
 ///
-/// The final matching sequence will be a trivial matching sequence of (a.len(), b.len(), 0) and will be the only match of length 0.
+/// The final matching sequence will be a trivial matching sequence of (a.len(),
+/// b.len(), 0) and will be the only match of length 0.
 ///
 /// ```
 /// # use fuzzywuzzy::utils::get_matching_blocks;
@@ -105,15 +180,19 @@ fn find_longest_match<'a>(
 #[allow(clippy::many_single_char_names)]
 pub fn get_matching_blocks<'a>(a: &'a str, b: &'a str) -> Vec<(usize, usize, usize)> {
     let flipped;
-    let (shorter, longer) = if a.len() <= b.len() {
-        flipped = false;
-        (a, b)
-    } else {
-        flipped = true;
-        (b, a)
+    // Handle utf-8 encodings
+    let (shorter, len1, longer, len2) = {
+        let a_len = a.chars().count();
+        let b_len = b.chars().count();
+        if a_len <= b_len {
+            flipped = false;
+            (a, a_len, b, b_len)
+        } else {
+            flipped = true;
+            (b, b_len, a, a_len)
+        }
     };
     // https://github.com/python-git/python/blob/master/Lib/difflib.py#L461
-    let (len1, len2) = (shorter.len(), longer.len());
     let mut queue: Vec<(usize, usize, usize, usize)> = vec![(0, len1, 0, len2)];
     let mut matching_blocks = Vec::new();
     while let Some((low1, high1, low2, high2)) = queue.pop() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -78,14 +78,13 @@ mod test {
 
     #[test]
     fn short() {
-        slice_utf8("ö", 0, 1);
+        assert_eq!(slice_utf8("ö", 0, 1), "ö");
     }
 
     #[test]
     fn arabic() {
         let s = "من"; // entire string is unicode
-        println!("found length {}", s.chars().count());
-        slice_utf8(s, 0, 2);
+        assert_eq!(slice_utf8(s, 0, 2), s);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -138,18 +138,6 @@ fn find_longest_match<'a>(
     // if only one match If multiple matches for a given block size and index,
     // return the one that starts earliest in b.
     let longsub = slice_utf8(longer, low2, high2).unwrap();
-    let backup = &longer[low2..high2];
-    if longsub != backup {
-        println!(
-            "backup: {:?} != longsub: {:?} on string: {:?}[{}..{}] with len {}",
-            backup,
-            longsub,
-            longer,
-            low2,
-            high2,
-            longer.chars().count()
-        )
-    }
     let slen = high1 - low1;
     for size in (1..slen + 1).rev() {
         for start in 0..slen - size + 1 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -65,9 +65,9 @@ mod test {
     use super::*;
 
     #[test]
-    fn slice_in_the_middle() {
-        let s = "this is a test"; // No unicode
-        assert_eq!(slice_utf8(s, 3, 6), &s[3..6]);
+    fn slice_at_the_end() {
+        let s = "this is a test"; // No Unicode
+        assert_eq!(slice_utf8(s, 3, s.len()), &s[3..(s.len())]);
     }
 
     #[test]
@@ -83,7 +83,7 @@ mod test {
 
     #[test]
     fn arabic() {
-        let s = "من";
+        let s = "من"; // entire string is unicode
         println!("found length {}", s.chars().count());
         slice_utf8(s, 0, 2);
     }
@@ -98,10 +98,10 @@ mod test {
 /// A function to handle slicing into strings which may contain unicode.
 ///
 /// Unlike Python, Rust cares deeply about unicode strings and ensuring every
-/// slice into them remains valid. As sliceing assumes that each enicode
-/// charicter is either in or outside of a slice, a simple slice operation can
+/// slice into them remains valid. As slicing assumes that each Unicode
+/// character is either in or outside of a slice, a simple slice operation can
 /// panic when run on a Rust string. We manually slice a Rust string by
-/// iterating over it's charicter points. This avoids panic on unicode strings.
+/// iterating over it's character points. This avoids panic on unicode strings.
 ///
 /// typical usage would be:
 ///     `slice_utf8(simple_string, 3, 7)` instead of `&simple_string[3..7]``
@@ -145,6 +145,8 @@ fn slice_utf8(string: &str, low: usize, high: usize) -> &str {
     if high_index.is_none() && high == string.chars().count() {
         high_index = Some(string.len());
     }
+
+    #[cfg(debug)]
     if high_index.is_none() || low_index.is_none() {
         eprintln!("About to crash on {:?}[{}..{}]", string, low, high);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -195,7 +195,7 @@ pub fn get_matching_blocks<'a>(a: &'a str, b: &'a str) -> Vec<(usize, usize, usi
             }
         }
     }
-    matching_blocks.sort(); // Is this necessary?
+    matching_blocks.sort_unstable(); // Is this necessary?
     let (mut i1, mut j1, mut k1) = (0, 0, 0);
     let mut non_adjacent = Vec::new();
     for (i2, j2, k2) in matching_blocks {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,15 +63,22 @@ pub fn validate_string(s: &str) -> bool {
 mod test {
     #[allow(unused_imports)]
     use super::*;
+
     #[test]
     fn slice_in_the_middle() {
         let s = "this is a test"; // No unicode
         assert_eq!(slice_utf8(s, 3, 6), Some(&s[3..6]));
     }
+
     #[test]
     fn slice_in_the_utf8() {
         let s = "ϵthiϕś αβ a test"; // Unicode
         assert_eq!(slice_utf8(s, 2, 6), Some("hiϕś"));
+    }
+
+    #[test]
+    fn test_short() {
+        slice_utf8("ö", 0, 1);
     }
 }
 
@@ -100,7 +107,7 @@ fn slice_utf8(string: &str, low: usize, high: usize) -> Option<&str> {
         high_index = if let Some((i, _)) = indices.next() {
             Some(i)
         } else {
-            low_index.map(|l| l + 1)
+            Some(string.len())
         };
     } else {
         for (i, e) in &mut indices {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -146,10 +146,20 @@ fn slice_utf8(string: &str, low: usize, high: usize) -> &str {
         high_index = Some(string.len());
     }
 
-    #[cfg(debug)]
-    if high_index.is_none() || low_index.is_none() {
-        eprintln!("About to crash on {:?}[{}..{}]", string, low, high);
-    }
+    debug_assert!(
+        high_index.is_some(),
+        "High value not calculated on input {:?}[{}..{}]",
+        string,
+        low,
+        high
+    );
+    debug_assert!(
+        low_index.is_some(),
+        "Low value not calculated on input {:?}[{}..{}]",
+        string,
+        low,
+        high
+    );
 
     let high = high_index.unwrap();
     let low = low_index.unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,7 +86,7 @@ mod test {
 /// typical usage would be:
 ///     `slice_utf8(simple_string, 3, 7)` instead of `&simple_string[3..7]``
 ///
-fn slice_utf8<'a>(string: &'a str, low: usize, high: usize) -> Option<&'a str> {
+fn slice_utf8(string: &str, low: usize, high: usize) -> Option<&str> {
     let mut indices = string.char_indices().enumerate().map(|(e, (i, _))| (i, e));
     let mut low_index = None;
     let mut high_index = None;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -116,7 +116,7 @@ fn slice_utf8<'a>(string: &'a str, low: usize, high: usize) -> Option<&'a str> {
         }
     }
 
-    low_index.zip(high_index).map(|(l, h)| &string[l..h])
+    Some(&string[low_index?..high_index?])
 }
 
 fn find_longest_match<'a>(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -142,6 +142,12 @@ fn slice_utf8(string: &str, low: usize, high: usize) -> &str {
             }
         }
     }
+    if high_index.is_none() && high == string.chars().count() {
+        high_index = Some(string.len());
+    }
+    if high_index.is_none() || low_index.is_none() {
+        eprintln!("About to crash on {:?}[{}..{}]", string, low, high);
+    }
 
     let high = high_index.unwrap();
     let low = low_index.unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -104,6 +104,7 @@ fn slice_utf8(string: &str, low: usize, high: usize) -> &str {
     // grab the byte-offset of the element *after* the ending character in case
     // the ending character is multi-byte
     // if we selected for the entire slice, there will not be a next element
+    #[allow(clippy::or_fun_call)]
     let high_index = indices.next().map(|(bo, _)| bo).unwrap_or(string.len());
     &string[low_index..high_index]
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,8 +77,15 @@ mod test {
     }
 
     #[test]
-    fn test_short() {
+    fn short() {
         slice_utf8("ö", 0, 1);
+    }
+
+    #[test]
+    fn arabic() {
+        let s = "من";
+        println!("found length {}", s.chars().count());
+        slice_utf8(s, 0, 2);
     }
 }
 
@@ -97,27 +104,28 @@ fn slice_utf8(string: &str, low: usize, high: usize) -> Option<&str> {
     let mut indices = string.char_indices().enumerate().map(|(e, (i, _))| (i, e));
     let mut low_index = None;
     let mut high_index = None;
+    let mut calc_high_index = |mut indices: std::iter::Map<_, _>| {
+        high_index = Some(if let Some((i, _)) = indices.next() {
+            i
+        } else {
+            string.len()
+        })
+    };
+    // Find low bound
     for (i, e) in &mut indices {
         if e == low {
             low_index = Some(i);
             break;
         }
     }
+    // find high bound
     if low + 1 == high {
-        high_index = if let Some((i, _)) = indices.next() {
-            Some(i)
-        } else {
-            Some(string.len())
-        };
+        calc_high_index(indices);
     } else {
-        for (i, e) in &mut indices {
+        for (_, e) in &mut indices {
             // Rust excludes the last index
             if e + 1 == high {
-                if let Some((i, _)) = indices.next() {
-                    high_index = Some(i);
-                } else {
-                    high_index = Some(i + 1);
-                }
+                calc_high_index(indices);
                 break;
             }
         }


### PR DESCRIPTION
Slicing into arbitrary rust strings can panic. It assumes that all slices without overflow are valid, which is untrue. I provide an `O(n)` slice function into arbitrary rust strings. It does not panic, and otherwise behaves like rust slices. I also change `len()` to `chars().count()` as it also causes problems with unicode characters. 