### PR TITLE
implement normalization + segmentation + primitives modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ normalization = ["unicode-normalization"]
 [dependencies]
 unicode-segmentation = { version = "1.7.1", optional = true }
 unicode-normalization = { version = "0.1.17", optional = true }
+
+[dev-dependencies]
+rand = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fuzzywuzzy"
 version = "0.0.2"
+edition = "2018"
 authors = ["Logan", "Sean"]
 description = "A pure-Rust clone of the incredibly useful fuzzy string matching python package, FuzzyWuzzy."
 repository = "https://github.com/logannc/fuzzywuzzy-rs"
@@ -10,4 +11,11 @@ keywords = ["string", "text", "processing", "matching", "fuzzy"]
 categories = ["text-processing"]
 
 
+[features]
+default = ["segmentation", "normalization"]
+segmentation = ["unicode-segmentation"]
+normalization = ["unicode-normalization"]
+
 [dependencies]
+unicode-segmentation = { version = "1.7.1", optional = true }
+unicode-normalization = { version = "0.1.17", optional = true }

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -1,7 +1,7 @@
 //! Fuzzy string matching scoring primitives.
 
+use crate::utils;
 use std::collections::HashSet;
-use utils;
 
 /// Returns the ratio of the length of matching character sequences to the sum of the length of the input strings.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,7 @@
 #[macro_use]
 pub mod utils;
 pub mod fuzz;
+pub mod normalization;
+pub mod primitives;
 pub mod process;
+pub mod segmentation;

--- a/src/normalization.rs
+++ b/src/normalization.rs
@@ -1,0 +1,163 @@
+//! Normalizer trait and default implementations.
+//!
+//! Normalization is how strings are normalized into characters you want to
+//! consider equal. For example, if you want a case insensitive comparison,
+//! you might consider the [LowerCaseNormalizer].
+//!
+//! ```
+//! # use fuzzywuzzy::normalization::{Normalizer, LowerCaseNormalizer, FormCNormalization, MultipleNormalizer};
+//! assert_eq!(LowerCaseNormalizer.normalize("this STRING"), LowerCaseNormalizer.normalize("THIS string"));
+//! let a1 = "ä"; // U+00E4
+//! let a2 = "ä"; // U+0061 + U+0308
+//! let a3 = "Ä"; // U+0041 + U+0308
+//! assert_ne!(a1, a2);
+//! assert_eq!(FormCNormalization.normalize(a2), a1);
+//! let multiple_normalizers = MultipleNormalizer::with(vec![Box::new(LowerCaseNormalizer), Box::new(FormCNormalization)]);
+//! assert_eq!(multiple_normalizers.normalize(a3), a1);
+//! ```
+
+/// Represents a strategy for normalizing string characters into a canonical value of their equivalence class.
+///
+/// i.e., in a case-insensitive context, 'a' might be the canonical value for the equivalence class of ASCII A's: `['a', 'A']`.
+pub trait Normalizer {
+    fn normalize(&self, s: &str) -> String;
+}
+
+impl<F: Fn(&str) -> String> Normalizer for F {
+    fn normalize(&self, s: &str) -> String {
+        self(s)
+    }
+}
+
+/// Doesn't modify any characters. The Identity-transform [Normalizer].
+pub struct PassthroughNormalizer;
+
+impl Normalizer for PassthroughNormalizer {
+    fn normalize(&self, s: &str) -> String {
+        s.into()
+    }
+}
+
+// ew, need a better name
+/// Compose a sequence of [Normalizer]s together into one [Normalizer].
+///
+/// They are executed in order.
+pub struct MultipleNormalizer {
+    normalizers: Vec<Box<dyn Normalizer>>,
+}
+
+impl MultipleNormalizer {
+    pub fn with(normalizers: Vec<Box<dyn Normalizer>>) -> MultipleNormalizer {
+        MultipleNormalizer { normalizers }
+    }
+}
+
+impl Normalizer for MultipleNormalizer {
+    fn normalize(&self, s: &str) -> String {
+        let mut current = s.to_owned();
+        for normalizer in self.normalizers.iter() {
+            current = normalizer.normalize(&current);
+        }
+        current
+    }
+}
+
+/// Normalizes strings by lower-casing all letters.
+pub struct LowerCaseNormalizer;
+
+impl Normalizer for LowerCaseNormalizer {
+    fn normalize(&self, s: &str) -> String {
+        s.to_lowercase().into()
+    }
+}
+
+/// Removes non-ASCII codepoints.
+pub struct AsciiOnlyFilter;
+
+impl Normalizer for AsciiOnlyFilter {
+    fn normalize(&self, s: &str) -> String {
+        s.chars().filter(char::is_ascii).collect()
+    }
+}
+
+#[cfg(feature = "segmentation")]
+pub use self::unicode_normalizers::*;
+
+#[cfg(feature = "segmentation")]
+mod unicode_normalizers {
+    use super::Normalizer;
+    use unicode_normalization::UnicodeNormalization;
+
+    /// Performs Unicode Normalization Form C (canonical decomposition followed by canonical composition).
+    ///
+    /// This just delegates to [unicode_normalization].
+    pub struct FormCNormalization;
+
+    impl Normalizer for FormCNormalization {
+        fn normalize(&self, s: &str) -> String {
+            s.nfc().collect()
+        }
+    }
+
+    /// Performs Unicode Normalization Form KC (compatibility decomposition followed by canonical composition).
+    ///
+    /// This just delegates to [unicode_normalization].
+    pub struct FormKCNormalization;
+
+    impl Normalizer for FormKCNormalization {
+        fn normalize(&self, s: &str) -> String {
+            s.nfkc().collect()
+        }
+    }
+
+    /// Performs Unicode Normalization Form D (canonical decomposition).
+    ///
+    /// This just delegates to [unicode_normalization].
+    /// ```
+    /// # use fuzzywuzzy::normalization::{Normalizer, FormDNormalization};
+    /// // FormDNormalization.normalize(U+00E4) == (U+0061 + U+0308)
+    /// assert_eq!(FormDNormalization.normalize("ä"), "a\u{0308}");
+    /// ```
+    pub struct FormDNormalization;
+    impl Normalizer for FormDNormalization {
+        fn normalize(&self, s: &str) -> String {
+            s.nfd().collect()
+        }
+    }
+
+    /// Performs Unicode Normalization Form KD (compatibility decomposition).
+    ///
+    /// This just delegates to [unicode_normalization].
+    pub struct FormKDNormalization;
+    impl Normalizer for FormKDNormalization {
+        fn normalize(&self, s: &str) -> String {
+            s.nfkd().collect()
+        }
+    }
+
+    /// Performs CJK Compatibility Ideograph-to-Standarized Variation Sequence normalization.
+    ///
+    /// This just delegates to [unicode_normalization]. "This is not part of the canonical or compatibility decomposition algorithms, but performing it before those algorithms produces normalized output which better preserves the intent of the original text."
+    pub struct CJKNormalization;
+    impl Normalizer for CJKNormalization {
+        fn normalize(&self, s: &str) -> String {
+            s.cjk_compat_variants().collect()
+        }
+    }
+
+    /// Decomposes a string, then removes non-ascii code points.
+    ///
+    /// ```
+    /// # use fuzzywuzzy::normalization::{Normalizer, UnicodeToAsciiNormalization};
+    /// // U+00E4
+    /// assert_eq!(UnicodeToAsciiNormalization.normalize("ä"), "a");
+    /// // U+0061 + U+0308
+    /// assert_eq!(UnicodeToAsciiNormalization.normalize("a\u{0308}"), "a");
+    /// ```
+    pub struct UnicodeToAsciiNormalization;
+    impl Normalizer for UnicodeToAsciiNormalization {
+        fn normalize(&self, s: &str) -> String {
+            s.nfd().filter(char::is_ascii).collect()
+        }
+    }
+}

--- a/src/normalization.rs
+++ b/src/normalization.rs
@@ -67,7 +67,7 @@ pub struct LowerCaseNormalizer;
 
 impl Normalizer for LowerCaseNormalizer {
     fn normalize(&self, s: &str) -> String {
-        s.to_lowercase().into()
+        s.to_lowercase()
     }
 }
 

--- a/src/normalization.rs
+++ b/src/normalization.rs
@@ -5,20 +5,31 @@
 //! you might consider the [LowerCaseNormalizer].
 //!
 //! ```
-//! # use fuzzywuzzy::normalization::{Normalizer, LowerCaseNormalizer, FormCNormalization, MultipleNormalizer};
+//! # use fuzzywuzzy::normalization::{Normalizer, LowerCaseNormalizer, FormCNormalizer, ComposedNormalizer};
 //! assert_eq!(LowerCaseNormalizer.normalize("this STRING"), LowerCaseNormalizer.normalize("THIS string"));
 //! let a1 = "ä"; // U+00E4
 //! let a2 = "ä"; // U+0061 + U+0308
 //! let a3 = "Ä"; // U+0041 + U+0308
 //! assert_ne!(a1, a2);
-//! assert_eq!(FormCNormalization.normalize(a2), a1);
-//! let multiple_normalizers = MultipleNormalizer::with(vec![Box::new(LowerCaseNormalizer), Box::new(FormCNormalization)]);
+//! assert_eq!(FormCNormalizer.normalize(a2), a1);
+//! let multiple_normalizers = ComposedNormalizer::with(
+//!     vec![Box::new(LowerCaseNormalizer), Box::new(FormCNormalizer)]);
 //! assert_eq!(multiple_normalizers.normalize(a3), a1);
 //! ```
 
 /// Represents a strategy for normalizing string characters into a canonical value of their equivalence class.
 ///
 /// i.e., in a case-insensitive context, 'a' might be the canonical value for the equivalence class of ASCII A's: `['a', 'A']`.
+///
+/// In addition to implementers of the trait, functions with a matching type signature also work.
+/// ```
+/// # use fuzzywuzzy::normalization::{Normalizer, LowerCaseNormalizer};
+/// let test_string = "test STRING";
+/// fn custom_normalizer(s: &str) -> String { s.to_lowercase() }
+/// assert_eq!(
+///    LowerCaseNormalizer.normalize(&test_string),
+///    custom_normalizer.normalize(&test_string));
+/// ```
 pub trait Normalizer {
     fn normalize(&self, s: &str) -> String;
 }
@@ -30,6 +41,16 @@ impl<F: Fn(&str) -> String> Normalizer for F {
 }
 
 /// Doesn't modify any characters. The Identity-transform [Normalizer].
+///
+/// ```
+/// # use fuzzywuzzy::normalization::{Normalizer, PassthroughNormalizer};
+/// use rand::{thread_rng, Rng};
+/// use rand::distributions::Alphanumeric;
+/// let random_string: String = thread_rng()
+///              .sample_iter(&Alphanumeric)
+///              .take(16).map(char::from).collect();
+/// assert_eq!(PassthroughNormalizer.normalize(&random_string), random_string);
+/// ```
 pub struct PassthroughNormalizer;
 
 impl Normalizer for PassthroughNormalizer {
@@ -38,21 +59,28 @@ impl Normalizer for PassthroughNormalizer {
     }
 }
 
-// ew, need a better name
 /// Compose a sequence of [Normalizer]s together into one [Normalizer].
 ///
-/// They are executed in order.
-pub struct MultipleNormalizer {
+/// They are executed in sequential order.
+/// ```
+/// # use fuzzywuzzy::normalization::{Normalizer, LowerCaseNormalizer, FormCNormalizer, ComposedNormalizer};
+/// let a1 = "ä"; // U+00E4
+/// let a2 = "Ä"; // U+0041 + U+0308
+/// let multiple_normalizers = ComposedNormalizer::with(
+///     vec![Box::new(LowerCaseNormalizer), Box::new(FormCNormalizer)]);
+/// assert_eq!(multiple_normalizers.normalize(a2), a1);
+/// ```
+pub struct ComposedNormalizer {
     normalizers: Vec<Box<dyn Normalizer>>,
 }
 
-impl MultipleNormalizer {
-    pub fn with(normalizers: Vec<Box<dyn Normalizer>>) -> MultipleNormalizer {
-        MultipleNormalizer { normalizers }
+impl ComposedNormalizer {
+    pub fn with(normalizers: Vec<Box<dyn Normalizer>>) -> ComposedNormalizer {
+        ComposedNormalizer { normalizers }
     }
 }
 
-impl Normalizer for MultipleNormalizer {
+impl Normalizer for ComposedNormalizer {
     fn normalize(&self, s: &str) -> String {
         let mut current = s.to_owned();
         for normalizer in self.normalizers.iter() {
@@ -63,6 +91,11 @@ impl Normalizer for MultipleNormalizer {
 }
 
 /// Normalizes strings by lower-casing all letters.
+///
+/// ```
+/// # use fuzzywuzzy::normalization::{Normalizer, LowerCaseNormalizer};
+/// assert_eq!(LowerCaseNormalizer.normalize("this STRING"), LowerCaseNormalizer.normalize("THIS string"));
+/// ```
 pub struct LowerCaseNormalizer;
 
 impl Normalizer for LowerCaseNormalizer {
@@ -72,9 +105,17 @@ impl Normalizer for LowerCaseNormalizer {
 }
 
 /// Removes non-ASCII codepoints.
-pub struct AsciiOnlyFilter;
+///
+/// Notably, this does not ASCII-ify non-ASCII characters, it just removes them.
+/// If you want to turn characters into ASCII decompositions, look at
+/// [FormDNormalizer], [FormKDNormalizer], or [UnicodeToAsciiNormalizer].
+/// ```
+/// # use fuzzywuzzy::normalization::{Normalizer, AsciiOnlyNormalizer};
+/// assert_eq!(AsciiOnlyNormalizer.normalize("äbc"), "bc");
+/// ```
+pub struct AsciiOnlyNormalizer;
 
-impl Normalizer for AsciiOnlyFilter {
+impl Normalizer for AsciiOnlyNormalizer {
     fn normalize(&self, s: &str) -> String {
         s.chars().filter(char::is_ascii).collect()
     }
@@ -88,74 +129,105 @@ mod unicode_normalizers {
     use super::Normalizer;
     use unicode_normalization::UnicodeNormalization;
 
-    /// Performs Unicode Normalization Form C (canonical decomposition followed by canonical composition).
+    /// Performs Unicode Normalization Form C (canonical decomposition followed by canonical composition). Requires default feature "normalization".
     ///
-    /// This just delegates to [unicode_normalization].
-    pub struct FormCNormalization;
+    /// This just delegates to [unicode_normalization::UnicodeNormalization::nfc].
+    ///
+    /// ```
+    /// # use fuzzywuzzy::normalization::{Normalizer, FormCNormalizer};
+    /// let a1 = "ä"; // U+00E4
+    /// let a2 = "ä"; // U+0061 + U+0308
+    /// assert_ne!(a1, a2);
+    /// assert_eq!(FormCNormalizer.normalize(a2), a1);
+    /// ```
+    pub struct FormCNormalizer;
 
-    impl Normalizer for FormCNormalization {
+    impl Normalizer for FormCNormalizer {
         fn normalize(&self, s: &str) -> String {
             s.nfc().collect()
         }
     }
 
-    /// Performs Unicode Normalization Form KC (compatibility decomposition followed by canonical composition).
+    /// Performs Unicode Normalization Form KC (compatibility decomposition followed by canonical composition). Requires default feature "normalization".
     ///
-    /// This just delegates to [unicode_normalization].
-    pub struct FormKCNormalization;
+    /// This just delegates to [unicode_normalization::UnicodeNormalization::nfkc].
+    ///
+    /// ```
+    /// # use fuzzywuzzy::normalization::{Normalizer, FormKCNormalizer};
+    /// let a1 = "ä"; // U+00E4
+    /// let a2 = "ä"; // U+0061 + U+0308
+    /// assert_ne!(a1, a2);
+    /// assert_eq!(FormKCNormalizer.normalize(a2), a1);
+    /// ```
+    pub struct FormKCNormalizer;
 
-    impl Normalizer for FormKCNormalization {
+    impl Normalizer for FormKCNormalizer {
         fn normalize(&self, s: &str) -> String {
             s.nfkc().collect()
         }
     }
 
-    /// Performs Unicode Normalization Form D (canonical decomposition).
+    /// Performs Unicode Normalization Form D (canonical decomposition). Requires default feature "normalization".
     ///
-    /// This just delegates to [unicode_normalization].
+    /// This just delegates to [unicode_normalization::UnicodeNormalization::nfd].
+    ///
     /// ```
-    /// # use fuzzywuzzy::normalization::{Normalizer, FormDNormalization};
-    /// // FormDNormalization.normalize(U+00E4) == (U+0061 + U+0308)
-    /// assert_eq!(FormDNormalization.normalize("ä"), "a\u{0308}");
+    /// # use fuzzywuzzy::normalization::{Normalizer, FormDNormalizer};
+    /// // FormDNormalizer.normalize(U+00E4) == (U+0061 + U+0308)
+    /// assert_eq!(FormDNormalizer.normalize("ä"), "a\u{0308}");
     /// ```
-    pub struct FormDNormalization;
-    impl Normalizer for FormDNormalization {
+    pub struct FormDNormalizer;
+    impl Normalizer for FormDNormalizer {
         fn normalize(&self, s: &str) -> String {
             s.nfd().collect()
         }
     }
 
-    /// Performs Unicode Normalization Form KD (compatibility decomposition).
+    /// Performs Unicode Normalization Form KD (compatibility decomposition). Requires default feature "normalization".
     ///
-    /// This just delegates to [unicode_normalization].
-    pub struct FormKDNormalization;
-    impl Normalizer for FormKDNormalization {
+    /// This just delegates to [unicode_normalization::UnicodeNormalization::nfkd].
+    ///
+    /// ```
+    /// # use fuzzywuzzy::normalization::{Normalizer, FormKDNormalizer};
+    /// // FormKDNormalizer.normalize(U+00E4) == (U+0061 + U+0308)
+    /// assert_eq!(FormKDNormalizer.normalize("ä"), "a\u{0308}");
+    /// ```
+    pub struct FormKDNormalizer;
+    impl Normalizer for FormKDNormalizer {
         fn normalize(&self, s: &str) -> String {
             s.nfkd().collect()
         }
     }
 
-    /// Performs CJK Compatibility Ideograph-to-Standarized Variation Sequence normalization.
+    /// Performs CJK Compatibility Ideograph-to-Standarized Variation Sequence normalization. Requires default feature "normalization".
     ///
-    /// This just delegates to [unicode_normalization]. "This is not part of the canonical or compatibility decomposition algorithms, but performing it before those algorithms produces normalized output which better preserves the intent of the original text."
-    pub struct CJKNormalization;
-    impl Normalizer for CJKNormalization {
+    /// This just delegates to [unicode_normalization::UnicodeNormalization::cjk_compat_variants].
+    ///
+    /// > "This is not part of the canonical or compatibility decomposition algorithms, but performing it before those algorithms produces normalized output which better preserves the intent of the original text." -- [unicode_normalization](unicode_normalization::UnicodeNormalization::cjk_compat_variants)
+    pub struct CJKNormalizer;
+    impl Normalizer for CJKNormalizer {
         fn normalize(&self, s: &str) -> String {
             s.cjk_compat_variants().collect()
         }
     }
 
-    /// Decomposes a string, then removes non-ascii code points.
+    /// Decomposes a string, then removes non-ascii code points. Requires default feature "normalization".
+    ///
+    /// Caution is needed when applying this [Normalizer].
+    /// While it may improve Latin-script based language comparisons because they can often decompose largely into ASCII + diacritics,
+    /// it will perform poorly on less ASCII-centric languages.
     ///
     /// ```
-    /// # use fuzzywuzzy::normalization::{Normalizer, UnicodeToAsciiNormalization};
+    /// # use fuzzywuzzy::normalization::{Normalizer, UnicodeToAsciiNormalizer};
     /// // U+00E4
-    /// assert_eq!(UnicodeToAsciiNormalization.normalize("ä"), "a");
+    /// assert_eq!(UnicodeToAsciiNormalizer.normalize("äbc"), "abc");
     /// // U+0061 + U+0308
-    /// assert_eq!(UnicodeToAsciiNormalization.normalize("a\u{0308}"), "a");
+    /// assert_eq!(UnicodeToAsciiNormalizer.normalize("a\u{0308}bc"), "abc");
+    /// // This is probably not what you want!
+    /// assert_eq!(UnicodeToAsciiNormalizer.normalize("किमप"), "");
     /// ```
-    pub struct UnicodeToAsciiNormalization;
-    impl Normalizer for UnicodeToAsciiNormalization {
+    pub struct UnicodeToAsciiNormalizer;
+    impl Normalizer for UnicodeToAsciiNormalizer {
         fn normalize(&self, s: &str) -> String {
             s.nfd().filter(char::is_ascii).collect()
         }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -37,7 +37,13 @@ pub fn get_matching_blocks<T: Eq>(a: &[T], b: &[T]) -> Vec<(usize, usize, usize)
     let mut queue = vec![(0, len1, 0, len2)];
     let mut matching_blocks = Vec::new();
     while let Some((low1, high1, low2, high2)) = queue.pop() {
-        let (i, j, k) = find_longest_match(shorter, longer, low1, high1, low2, high2);
+        // TODO: I'd like to convert this function to use MatchingStreak's internally.
+        // It might make it more clear to be comparing low1 < streak.idx1 instead of low1 < i
+        let MatchingStreak {
+            idx1: i,
+            idx2: j,
+            size: k,
+        } = find_longest_match(shorter, longer, low1, high1, low2, high2);
         debug_assert!(i <= shorter.len());
         debug_assert!(j <= longer.len());
         if k != 0 {
@@ -53,10 +59,13 @@ pub fn get_matching_blocks<T: Eq>(a: &[T], b: &[T]) -> Vec<(usize, usize, usize)
     matching_blocks.sort_unstable();
     let (mut i1, mut j1, mut k1) = (0, 0, 0);
     let mut non_adjacent = Vec::new();
+    // collapse adjacent blocks
     for (i2, j2, k2) in matching_blocks {
         if i1 + k1 == i2 && j1 + k1 == j2 {
+            // blocks are adjacent, combine
             k1 += k2;
         } else {
+            // not adjacent, push if it isn't the first dummy block.
             if k1 != 0 {
                 non_adjacent.push((i1, j1, k1));
             }
@@ -75,7 +84,39 @@ pub fn get_matching_blocks<T: Eq>(a: &[T], b: &[T]) -> Vec<(usize, usize, usize)
         .collect()
 }
 
-/// TODO: doc + tests
+/// Represents a matching streak of characters between two strings.
+///
+/// See [find_longest_match] for details.
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub struct MatchingStreak {
+    /// The index into the first (typically shorter) string where the streak begins.
+    pub idx1: usize,
+    /// The index into the second (typically longer) string where the streak begins.
+    pub idx2: usize,
+    /// The size of the matching character streak.
+    pub size: usize,
+}
+
+/// Finds the longest matching streak of characters of `shorter[low1..high1]` in `longer[low2..high2]`.
+///
+/// Returned as a [MatchingStreak] where
+/// `idx1` is an index into `shorter` where the streak begins,
+/// `idx2` is an index into `longer` where the streak begins,
+/// and `size` is the length of the streak.
+///
+/// ```
+/// # use fuzzywuzzy::segmentation::{Segmenter, CodePointSegmenter};
+/// # use fuzzywuzzy::primitives::{ find_longest_match, MatchingStreak};
+/// let a = CodePointSegmenter.segment("foo bar");
+/// let b = CodePointSegmenter.segment("foo bar baz");
+/// let c = CodePointSegmenter.segment("bar baz");
+/// assert_eq!(find_longest_match(&a, &b, 0, a.len(), 0, b.len()),
+///                               MatchingStreak{ idx1: 0, idx2: 0, size: 7 });
+/// assert_eq!(find_longest_match(&a, &c, 0, a.len(), 0, c.len()),
+///                               MatchingStreak{ idx1: 3, idx2: 3, size: 3 });
+/// assert_eq!(find_longest_match(&c, &b, 0, c.len(), 0, b.len()),
+///                               MatchingStreak{ idx1: 0, idx2: 4, size: 7 });
+/// ```
 pub fn find_longest_match<T: Eq>(
     shorter: &[T],
     longer: &[T],
@@ -83,7 +124,7 @@ pub fn find_longest_match<T: Eq>(
     high1: usize,
     low2: usize,
     high2: usize,
-) -> (usize, usize, usize) {
+) -> MatchingStreak {
     // https://github.com/python-git/python/blob/master/Lib/difflib.py#L351
     // algo:
     //  In other words, of all maximal matching blocks, return one that
@@ -100,6 +141,7 @@ pub fn find_longest_match<T: Eq>(
     debug_assert!(low2 <= high2);
     debug_assert!(high1 <= shorter.len());
     debug_assert!(high2 <= longer.len());
+    debug_assert!(high1 - low1 <= high2 - low2);
     let longsub = &longer[low2..high2];
     let len = high1 - low1;
     for size in (1..len + 1).rev() {
@@ -108,10 +150,18 @@ pub fn find_longest_match<T: Eq>(
             for window_start in 0..((high2 - low2) - size + 1) {
                 let window = &longsub[window_start..window_start + size];
                 if window == shortsub {
-                    return (low1 + start, low2 + window_start, size);
+                    return MatchingStreak {
+                        idx1: low1 + start,
+                        idx2: low2 + window_start,
+                        size,
+                    };
                 }
             }
         }
     }
-    (low1, low2, 0)
+    MatchingStreak {
+        idx1: low1,
+        idx2: low2,
+        size: 0,
+    }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,0 +1,117 @@
+//! Contains comparison primitives used to build up the rest of the library.
+
+/// Returns list of triples describing matching sequences.
+///
+/// The first number is the index in the first string of the beginning of the match.
+/// The second number is the index of the second string of the beginning of the match.
+/// The final number is the length of the match.
+///
+/// The final matching sequence will be a trivial matching sequence of (a.len(),
+/// b.len(), 0) and will be the only match of length 0.
+///
+/// ```
+/// # use fuzzywuzzy::segmentation::{Segmenter, CodePointSegmenter, GraphemeSegmenter};
+/// # use fuzzywuzzy::primitives::get_matching_blocks;
+/// assert_eq!(get_matching_blocks(&CodePointSegmenter.segment("abxcd"), &CodePointSegmenter.segment("abcd")), vec![(0, 0, 2), (3, 2, 2), (5, 4, 0)]);
+/// assert_eq!(get_matching_blocks(&CodePointSegmenter.segment("abcd"), &CodePointSegmenter.segment("abxcd")), vec![(0, 0, 2), (2, 3, 2), (4, 5, 0)]);
+/// assert_eq!(get_matching_blocks(&CodePointSegmenter.segment("chance"), &CodePointSegmenter.segment("スマホでchance")), vec![(0, 4, 6), (6, 10, 0)]);
+/// assert_eq!(get_matching_blocks(&GraphemeSegmenter.segment("chance"), &GraphemeSegmenter.segment("スマホでchance")), vec![(0, 4, 6), (6, 10, 0)]);
+/// assert_eq!(get_matching_blocks(&CodePointSegmenter.segment("किमप"), &CodePointSegmenter.segment("किमपि")), vec![(0, 0, 4), (4, 5, 0)]);
+/// assert_eq!(get_matching_blocks(&GraphemeSegmenter.segment("किमप"), &GraphemeSegmenter.segment("किमपि")), vec![(0, 0, 2), (3, 3, 0)]);
+/// ```
+#[allow(clippy::many_single_char_names)]
+pub fn get_matching_blocks<T: Eq>(a: &[T], b: &[T]) -> Vec<(usize, usize, usize)> {
+    let flipped;
+    let (shorter, len1, longer, len2) = {
+        let a_len = a.len();
+        let b_len = b.len();
+        if a_len <= b_len {
+            flipped = false;
+            (a, a_len, b, b_len)
+        } else {
+            flipped = true;
+            (b, b_len, a, a_len)
+        }
+    };
+    // https://github.com/python-git/python/blob/master/Lib/difflib.py#L461
+    let mut queue = vec![(0, len1, 0, len2)];
+    let mut matching_blocks = Vec::new();
+    while let Some((low1, high1, low2, high2)) = queue.pop() {
+        let (i, j, k) = find_longest_match(shorter, longer, low1, high1, low2, high2);
+        debug_assert!(i <= shorter.len());
+        debug_assert!(j <= longer.len());
+        if k != 0 {
+            matching_blocks.push((i, j, k));
+            if low1 < i && low2 < j {
+                queue.push((low1, i, low2, j));
+            }
+            if i + k < high1 && j + k < high2 {
+                queue.push((i + k, high1, j + k, high2));
+            }
+        }
+    }
+    matching_blocks.sort_unstable();
+    let (mut i1, mut j1, mut k1) = (0, 0, 0);
+    let mut non_adjacent = Vec::new();
+    for (i2, j2, k2) in matching_blocks {
+        if i1 + k1 == i2 && j1 + k1 == j2 {
+            k1 += k2;
+        } else {
+            if k1 != 0 {
+                non_adjacent.push((i1, j1, k1));
+            }
+            i1 = i2;
+            j1 = j2;
+            k1 = k2;
+        }
+    }
+    if k1 != 0 {
+        non_adjacent.push((i1, j1, k1));
+    }
+    non_adjacent.push((len1, len2, 0));
+    non_adjacent
+        .into_iter()
+        .map(|(i, j, k)| if flipped { (j, i, k) } else { (i, j, k) })
+        .collect()
+}
+
+/// TODO: doc + tests
+pub fn find_longest_match<T: Eq>(
+    shorter: &[T],
+    longer: &[T],
+    low1: usize,
+    high1: usize,
+    low2: usize,
+    high2: usize,
+) -> (usize, usize, usize) {
+    // https://github.com/python-git/python/blob/master/Lib/difflib.py#L351
+    // algo:
+    //  In other words, of all maximal matching blocks, return one that
+    //  starts earliest in a, and of all those maximal matching blocks that
+    //  start earliest in a, return the one that starts earliest in b.
+    //
+    // In MY words: So, try to find a block of size `shorter.len()`[1], else
+    // decrement size. For each block size, start from the front of `longer`
+    // and return the earliest match for a given block size and index.
+    //
+    // [1] - because of the calling context, we actually use `high1 - low1`
+    // for the length because we might be indexing into the middle of `shorter`
+    debug_assert!(low1 <= high1);
+    debug_assert!(low2 <= high2);
+    debug_assert!(high1 <= shorter.len());
+    debug_assert!(high2 <= longer.len());
+    let longsub = &longer[low2..high2];
+    let len = high1 - low1;
+    for size in (1..len + 1).rev() {
+        for start in 0..len - size + 1 {
+            let shortsub = &shorter[low1 + start..low1 + start + size];
+            for window_start in 0..((high2 - low2) - size + 1) {
+                let window = &longsub[window_start..window_start + size];
+                if window == shortsub {
+                    return (low1 + start, low2 + window_start, size);
+                }
+            }
+        }
+    }
+    (low1, low2, 0)
+}

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -1,0 +1,102 @@
+//! Segmenter trait and default implementations.
+//!
+//! Segmentation is how strings are split into tokens for comparison.
+//! For example, two strings that *appear* identical might have different byte-level representations.
+//!
+//! Take `ä` and `ä`. Visually, these should be identical. However, the former
+//! is Unicode character [ä (U+00E4)](https://www.compart.com/en/unicode/U+00E4)
+//! while the latter is two adjacent Unicode characters [a (U+0061)](https://www.compart.com/en/unicode/U+0061)
+//! and [◌̈ (U+0308)](https://www.compart.com/en/unicode/U+0308).
+//!
+//! Depending on the [Segmenter] used, comparing these strings will return different results.
+//!
+//! ```
+//! # use fuzzywuzzy::segmentation::{Segmenter, ByteSegmenter};
+//! // U+00E4
+//! assert_eq!(ByteSegmenter.segment("ä"), vec![0xc3u8, 0xa4u8]);
+//! // U+0061 + U+0308
+//! assert_eq!(ByteSegmenter.segment("ä"), vec![0x61u8, 0xccu8, 0x88u8]);
+//! ```
+//! Given this segmentation, we would expect a comparison to return 0% similarity because every byte is different!
+//!
+//! However, even with more advanced segmentation strategies like [code point segmentation](CodePointSegmenter)
+//! or [grapheme segmentation](GraphemeSegmenter), these will still have 0% similarity by any comparison algorithm.
+//!
+//! ```
+//! # use fuzzywuzzy::segmentation::{Segmenter, CodePointSegmenter, GraphemeSegmenter};
+//! // U+00E4
+//! assert_eq!(CodePointSegmenter.segment("ä"), vec!['ä']);
+//! assert_eq!(GraphemeSegmenter.segment("ä"), vec!["ä"]);
+//! // U+0061 + U+0308
+//! assert_eq!(CodePointSegmenter.segment("ä"), vec!['a', '\u{0308}']);
+//! assert_eq!(GraphemeSegmenter.segment("ä"), vec!["ä"]);
+//! // U+00E4 vs. U+0061 + U+0308
+//! assert_ne!(GraphemeSegmenter.segment("ä"), GraphemeSegmenter.segment("ä"));
+//! ```
+//!
+//! In order to usefully compare strings like these, [normalization][crate::normalization] must be done prior to segmentation.
+
+/// Represents a strategy for segmenting a string into units for comparison.
+///
+/// The trait is also implemented for functions matching the signature of the `segment` method.
+pub trait Segmenter<'a> {
+    /// The type of the unit of comparison this strategy operates on.
+    type Output: 'a + Eq;
+    /// Produces units of comparison from a string according to the segmentation strategy.
+    fn segment(&self, s: &'a str) -> Vec<Self::Output>;
+}
+
+impl<'a, F: Fn(&str) -> Vec<T>, T: 'a + Eq> Segmenter<'a> for F {
+    type Output = T;
+    fn segment(&self, s: &'a str) -> Vec<Self::Output> {
+        self(s)
+    }
+}
+
+/// A strategy for segmenting strings into their constituent bytes.
+pub struct ByteSegmenter;
+
+impl<'a> Segmenter<'a> for ByteSegmenter {
+    // Returns an owned `Vec<u8>` because allocating additional `u8`s is cheaper than pointers into the original string.
+    type Output = u8;
+    fn segment(&self, s: &'a str) -> Vec<Self::Output> {
+        s.as_bytes().iter().map(|x| *x).collect()
+    }
+}
+
+/// A strategy for segmenting strings into their constituent Unicode code points.
+///
+/// Internally, this is just `s.chars().collect()`.
+///
+/// Note that `char` is a Unicode Scalar Value which is a subset of Unicode code points disallowing surrogates.
+/// UTF-8, which all Rust strings are guaranteed to be, also disallows surrogates.
+/// So all of the Unicode Scalar Values produced here are UTF-8 code points.
+pub struct CodePointSegmenter;
+
+impl<'a> Segmenter<'a> for CodePointSegmenter {
+    type Output = char;
+    fn segment(&self, s: &'a str) -> Vec<Self::Output> {
+        s.chars().collect()
+    }
+}
+
+#[cfg(feature = "segmentation")]
+pub use self::unicode_segmenters::*;
+
+#[cfg(feature = "segmentation")]
+mod unicode_segmenters {
+    use super::Segmenter;
+    use unicode_segmentation::UnicodeSegmentation;
+
+    /// A strategy for segmenting strings into their constituent Unicode graphemes. Requires default feature "segmentation".
+    ///
+    /// This just delegates to [unicode_segmentation].
+    pub struct GraphemeSegmenter;
+
+    impl<'a> Segmenter<'a> for GraphemeSegmenter {
+        type Output = &'a str;
+        fn segment(&self, s: &'a str) -> Vec<Self::Output> {
+            s.graphemes(true).collect()
+        }
+    }
+}

--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -60,7 +60,7 @@ impl<'a> Segmenter<'a> for ByteSegmenter {
     // Returns an owned `Vec<u8>` because allocating additional `u8`s is cheaper than pointers into the original string.
     type Output = u8;
     fn segment(&self, s: &'a str) -> Vec<Self::Output> {
-        s.as_bytes().iter().map(|x| *x).collect()
+        s.as_bytes().iter().copied().collect()
     }
 }
 


### PR DESCRIPTION
For #24 

This sets the stage to a comprehensive Unicode strategy.

A following PR will introduce methods that actually use these traits. I'm thinking a compatibility/easy module with sane defaults for compatibility with fuzzywuzzy. e.g., `fn ratio(a: &str, b: &str) -> u8 { other_ratio(a, b, normalization::SomeDefaultNormalization, segmentation::CodePointSegmentation) }`